### PR TITLE
Only do screenshots if it's in debug mode

### DIFF
--- a/wdio.conf.debug.js
+++ b/wdio.conf.debug.js
@@ -17,7 +17,7 @@ if (isDebug()) {
 }
 
 function afterTest(test) {
-  if (!test.passed) saveScreenshot(test)
+  if (isDebug() && !test.passed) saveScreenshot(test)
 }
 
 function onError(message) {


### PR DESCRIPTION
As you can't override this afterTest hook it should only be executed in debug mode automatically