### PR TITLE
Remove saveScreenshot from default afterTest hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ Returns the predefined capability.
 
 If current *capability* has property `viewportSize` this function will issue `WebdriverIO` command to resize the current browser *window* so that inner dimensions match `viewportSize`.
 
-### `util.saveScreenshot(test: object) : void`
+### `util.saveScreenshot(test: object, path: string) : void`
 
-Saves screenshot to given `screenshotPath` or tmp directory and logs error info to stdout.
+Saves screenshot to given `path` or tmp directory and logs error info to stdout.
 
 ### `util.printBrowserConsole() : void`
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Selenium commands will be executed **synchronously** by default. To override:
 ```js
   // wdio.conf.js
   const { WDIOConfigDefault, capabilities, util } = require('vue-cli-plugin-e2e-webdriverio')
-  const { resizeViewport } = util
+  const { resizeViewport, isDebug } = util
   const { Chrome } = capabilities
 
   const base = WDIOConfigDefault().config
@@ -126,6 +126,15 @@ Selenium commands will be executed **synchronously** by default. To override:
       resizeViewport,
       anotherFunction,
     ]
+
+    afterTest: [
+      (test) => {
+        if (isDebug() && !test.passed) {
+          saveScreenshot(test, 'path/to/screenshot.png')
+        }
+      },
+      // ...
+    }
 
     // OR
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,13 +56,10 @@ function resizeViewport() {
 }
 
 function screenshotPath() {
-  const { screenshotPath } = browser.options
-
-  return path.resolve(screenshotPath || os.tmpdir(), `${uuid.v4()}.png`)
+  return path.resolve(os.tmpdir(), `${uuid.v4()}.png`)
 }
 
-function saveScreenshot(test) {
-  const path = screenshotPath()
+function saveScreenshot(test, path = screenshotPath()) {
   const report = [`✖ ${test.parent} ${test.title}\n`, ` Screenshot: ${path}\n`]
 
   try {

--- a/wdio.conf.debug.js
+++ b/wdio.conf.debug.js
@@ -1,5 +1,5 @@
 const base = require('./wdio.conf.base').config
-const { isDebug, saveScreenshot, printBrowserConsole } = require('./lib/util')
+const { isDebug, printBrowserConsole } = require('./lib/util')
 
 const config = module.exports.config = {
   ...base,
@@ -16,16 +16,11 @@ if (isDebug()) {
   })
 }
 
-function afterTest(test) {
-  if (!test.passed) saveScreenshot(test)
-}
-
 function onError(message) {
   if (isDebug()) printBrowserConsole()
 }
 
 module.exports.hooks = [
   ...require('./wdio.conf.base').hooks,
-  afterTest,
   onError,
 ]


### PR DESCRIPTION
Per discussion in #8:

* Remove `saveScreenshot` from default afterTest hooks
* `saveScreenshot` accepts custom path
* Documents optional hook registration