### PR TITLE
merge chromeOptions

### DIFF
--- a/lib/capabilities/Chrome.js
+++ b/lib/capabilities/Chrome.js
@@ -1,5 +1,6 @@
 const Device = require('./Device')
 const chromeDriverArgs = require('./chromeDriverArgs')
+const { PLUGIN_NAME } = require('../constants')
 
 // @see http://chromedriver.chromium.org/mobile-emulation Differences between mobile emulation and real devices
 //
@@ -19,31 +20,15 @@ const chromeDriverArgs = require('./chromeDriverArgs')
 //     // ...
 //   })
 module.exports = class Chrome extends Device {
-  constructor(opts) {
-    super({ chromeOptions: {}, ...opts })
-
-    if (!this.chromeOptions.args) {
-      this.chromeOptions.args = this.defaultChromeDriverArgs
-    } else {
-      this.chromeOptions.args = [
-        ...new Set(this.defaultChromeDriverArgs.concat(this.chromeOptions.args)),
-      ]
-    }
-  }
-
-  get defaultChromeDriverArgs() {
+  constructor(opts = {}) {
     const args = [
       ...chromeDriverArgs(),
       // @see https://bugs.chromium.org/p/chromium/issues/detail?id=820453#c6 tenuous status
       '--disable-infobars',
     ]
 
-    if (this.userAgent) {
-      args.push(`--user-agent=${this.userAgent}`)
-    }
-
-    if (this.viewportSize) {
-      const { width, height } = this.viewportSize
+    if (opts.viewportSize) {
+      const { width, height } = opts.viewportSize
 
       if (width && height) {
         args.push(
@@ -51,9 +36,36 @@ module.exports = class Chrome extends Device {
           // `--cast-initial-screen-width=${width}`,
           // `--cast-initial-screen-height=${height}`,
         )
+
+        // hide non-standard options behind a vendor prefix (otherwise
+        // chromedriver 75+ throws)
+        // see https://www.w3.org/TR/webdriver/#capabilities
+
+        opts[`${PLUGIN_NAME}:viewportSize`] = opts.viewportSize
       }
+
+      delete opts.viewportSize
     }
 
-    return args
+    if (opts.userAgent) {
+      args.push(`--user-agent=${opts.userAgent}`)
+      opts[`${PLUGIN_NAME}:userAgent`] = opts.userAgent
+      delete opts.userAgent
+    }
+
+    const chromeOptions = opts.chromeOptions || opts['goog:chromeOptions'] || {}
+
+    if (chromeOptions.args) {
+      args.push(...opts.chromeOptions.args)
+    }
+
+    delete opts.chromeOptions // requires vendor prefix
+
+    opts['goog:chromeOptions'] = {
+      ...chromeOptions,
+      args,
+    }
+
+    super(opts)
   }
 }


### PR DESCRIPTION
ensures supplied `chromeOptions` or `goog:chromeOptions` are merged in to the final capabilities, and illegal props are removed (e.g. `viewportSize`)