### PR TITLE
🐛 bug: workaround wdio 5.14.x only accepting relative config paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,15 @@ function handleConfig(args, rawArgs, api, options) {
 
   // Append config path to args
   process.env.VUE_CLI_WDIO_DEFAULT = configPath ? OFF : ON
-  rawArgs.push(configPath || WDIO_CONFIG_DEFAULT_PATH)
+
+  let resolvedConfigPath = configPath || WDIO_CONFIG_DEFAULT_PATH
+
+  if (path.isAbsolute(resolvedConfigPath)) {
+    // wdio runner only accepts relative paths
+    resolvedConfigPath = path.relative(process.cwd(), resolvedConfigPath)
+  }
+
+  rawArgs.push(resolvedConfigPath)
 }
 
 function switchMode(option, args, rawArgs, options, on, off) {


### PR DESCRIPTION
wdio 5.14.x introduces a bug (?) which break absolute config paths. this change ensures any paths passed to it are relative.